### PR TITLE
add error to pipelines.Drain

### DIFF
--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -240,16 +240,17 @@ func ForkMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Conte
 }
 
 // Drain blocks the current goroutine and receives all values from the provided channel until it has been closed. Each
-// value recieved is appended to a new slice, which is returned.
-func Drain[T any](ctx context.Context, in <-chan T) []T {
+// value recieved is appended to a new slice, which is returned. An error is returned along with a partial result if the
+// provided context is cancelled.
+func Drain[T any](ctx context.Context, in <-chan T) ([]T, error) {
 	var result []T
 	for {
 		select {
 		case <-ctx.Done():
-			return result
+			return result, ctx.Err()
 		case repo, ok := <-in:
 			if !ok {
-				return result
+				return result, nil
 			}
 			result = append(result, repo)
 		}

--- a/pipelines/pipelines_test.go
+++ b/pipelines/pipelines_test.go
@@ -295,7 +295,8 @@ func TestDrain(t *testing.T) {
 
 		in := pipelines.Chan([]int{1, 2, 34, 5, 6, 7, 8, 9})
 
-		result := pipelines.Drain(ctx, in)
+		result, err := pipelines.Drain(ctx, in)
+		is.Equal(err, nil)
 		is.Equal(result, []int{1, 2, 34, 5, 6, 7, 8, 9})
 	})
 	t.Run("halts on closed input channel", func(t *testing.T) {
@@ -304,7 +305,8 @@ func TestDrain(t *testing.T) {
 		in := make(chan string)
 		close(in)
 
-		result := pipelines.Drain(ctx, in)
+		result, err := pipelines.Drain(ctx, in)
+		is.Equal(err, nil)
 		is.Equal(len(result), 0)
 	})
 
@@ -315,7 +317,8 @@ func TestDrain(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		result := pipelines.Drain(ctx, in)
+		result, err := pipelines.Drain(ctx, in)
+		is.Equal(err.Error(), "context canceled")
 		is.Equal(len(result), 0)
 	})
 }


### PR DESCRIPTION
Realized the API needs an error in case a context cancellation results in a partial drain (before closure).