### PR TITLE
Add with done

### DIFF
--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -1,14 +1,15 @@
 // Package pipelines provides helper functions for constructing concurrent processing pipelines.
 // Each pipeline stage represents a single stage in a parallel computation, with an input channel and an output channel.
-// Generally, pipeline stages have signatures starting with a context and input channel as their first arguments, and returning a channel,
-// as below:
+// Generally, pipeline stages have signatures starting with a context and input channel as their first arguments, and
+// returning a channel, as below:
 //
 //   Stage[S,T any](ctx context.Context, in <-chan S, ...) <-chan T
 //
 // The return value from a pipeline stage is referred to as the stage's 'output' channel. Each stage is a non-blocking
 // call which starts one or more goroutines which listen on the input channel and send results to the output channel.
-// Goroutines started by each stage respond to context cancellation or closure of the input channel by closing its output channel and cleaning up all goroutines started.
-// Many pipeline stages take a function as an argument, which transform the input and output in some way.
+// Goroutines started by each stage respond to context cancellation or closure of the input channel by closing its
+// output channel and cleaning up all goroutines started. Many pipeline stages take a function as an argument, which
+// transform the input and output in some way.
 //
 // By default, each pipeline starts the minimum number of threads required for its operation, and returns an unbuffered channel.
 // These defaults can be modified by passing the result of WithBuffer or WithPool as optional arguments.
@@ -20,8 +21,36 @@ import (
 )
 
 type config[T any] struct {
-	channer func() chan T
-	workers int
+	channer    func() chan T
+	workers    int
+	outputs    int
+	doneCancel context.CancelFunc
+}
+
+func (c config[T]) makeOutputs() []chan T {
+	var result []chan T
+	for i := 0; i < c.outputs; i++ {
+		result = append(result, c.channer())
+	}
+	return result
+}
+
+// sendOnly casts an array of channels to receive-only channels.
+func sendOnly[T any](chans []chan T) []chan<- T {
+	result := make([]chan<- T, len(chans))
+	for i, ch := range chans {
+		result[i] = ch
+	}
+	return result
+}
+
+// recvOnly casts an array of channels to send-only channels
+func recvOnly[T any](chans []chan T) []<-chan T {
+	result := make([]<-chan T, len(chans))
+	for i, ch := range chans {
+		result[i] = ch
+	}
+	return result
 }
 
 // An OptionFunc is passed to optionally configure a pipeline stage.
@@ -44,10 +73,19 @@ func WithPool[T any](numWorkers int) OptionFunc[T] {
 	}
 }
 
+// WithDone returns a context which is cancelled when all goroutines started by this pipeline stage have shutdown.
+func WithDone[T any](ctx context.Context) (OptionFunc[T], context.Context) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return func(conf *config[T]) {
+		conf.doneCancel = cancel
+	}, ctx
+}
+
 func configure[T any](opts []OptionFunc[T]) config[T] {
 	result := config[T]{
 		channer: func() chan T { return make(chan T) },
 		workers: 1,
+		outputs: 1,
 	}
 	for _, opt := range opts {
 		opt(&result)
@@ -69,9 +107,9 @@ func Chan[T any](in []T) <-chan T {
 // Flatten provides a pipeline stage which converts a channel of slices to a channel of scalar values.
 // Each value contained in slices received from the input channel is sent to the output channel.
 func Flatten[T any](ctx context.Context, in <-chan []T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doFlatten(ctx, in, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doFlatten(ctx, in, out[0])
+	}, configure(opts)))
 }
 
 func doFlatten[T any](ctx context.Context, in <-chan []T, result chan<- T) {
@@ -91,9 +129,17 @@ func doFlatten[T any](ctx context.Context, in <-chan []T, result chan<- T) {
 // Map applies f to every value received from the input channel and sends the result to the output channel.
 // The output channel is closed when the input channel is closed or the provided context is cancelled.
 func Map[S, T any](ctx context.Context, in <-chan S, f func(S) T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doMap(ctx, in, f, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doMap(ctx, in, f, out[0])
+	}, configure(opts)))
+}
+
+func return1[T any](chans []<-chan T) <-chan T {
+	return chans[0]
+}
+
+func return2[T any](chans []<-chan T) (<-chan T, <-chan T) {
+	return chans[0], chans[1]
 }
 
 func doMap[S, T any](ctx context.Context, in <-chan S, f func(S) T, result chan<- T) {
@@ -117,9 +163,9 @@ func doMap[S, T any](ctx context.Context, in <-chan S, f func(S) T, result chan<
 // MapCtx applies f to every value received from its input channel and sends the result to its output channel.
 // The same context passed to MapCtx is passed as an argument to f.
 func MapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S) T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doMapCtx(ctx, in, f, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doMapCtx(ctx, in, f, out[0])
+	}, configure(opts)))
 }
 
 func doMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S) T, result chan<- T) {
@@ -143,9 +189,9 @@ func doMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context
 // FlatMap applies f to every value received from its input channel and sends all values found in the slice returned from
 // f to its output channel.
 func FlatMap[S, T any](ctx context.Context, in <-chan S, f func(S) []T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doFlatMap(ctx, in, f, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doFlatMap(ctx, in, f, out[0])
+	}, configure(opts)))
 }
 
 func doFlatMap[S, T any](ctx context.Context, in <-chan S, f func(S) []T, out chan<- T) {
@@ -166,9 +212,9 @@ func doFlatMap[S, T any](ctx context.Context, in <-chan S, f func(S) []T, out ch
 // f to its output channel.
 // The same context passed to FlatMapCtx is passed as an argument to f.
 func FlatMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S) []T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doFlatMapCtx(ctx, in, f, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doFlatMapCtx(ctx, in, f, out[0])
+	}, configure(opts)))
 }
 
 func doFlatMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S) []T, out chan<- T) {
@@ -187,9 +233,9 @@ func doFlatMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Con
 
 // Combine sends all values received from both of its input channels to its output channel.
 func Combine[T any](ctx context.Context, t1 <-chan T, t2 <-chan T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doCombine(ctx, t1, t2, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doCombine(ctx, t1, t2, out[0])
+	}, configure(opts)))
 }
 
 func doCombine[T any](ctx context.Context, t1 <-chan T, t2 <-chan T, out chan<- T) {
@@ -220,12 +266,10 @@ func doCombine[T any](ctx context.Context, t1 <-chan T, t2 <-chan T, out chan<- 
 // drained simultaneously to avoid blocking this pipeline stage.
 func Tee[T any](ctx context.Context, ch <-chan T, opts ...OptionFunc[T]) (<-chan T, <-chan T) {
 	conf := configure(opts)
-	chan1, chan2 := conf.channer(), conf.channer()
-	doOnPool(ctx, conf.workers, func(ctx context.Context, chans ...chan<- T) {
-		out1, out2 := chans[0], chans[1]
-		doTee(ctx, ch, out1, out2)
-	}, chan1, chan2)
-	return chan1, chan2
+	conf.outputs = 2
+	return return2(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doTee(ctx, ch, out[0], out[1])
+	}, conf))
 }
 
 func doTee[T any](ctx context.Context, ch <-chan T, chan1, chan2 chan<- T) {
@@ -260,9 +304,9 @@ func doTee[T any](ctx context.Context, ch <-chan T, chan1, chan2 chan<- T) {
 // WithCancel passes each value received from its input channel to its output channel.
 // If the provided context is cancelled or the input channel is closed, the output channel is also closed.
 func WithCancel[T any](ctx context.Context, ch <-chan T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doWithCancel(ctx, ch, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doWithCancel(ctx, ch, out[0])
+	}, configure(opts)))
 }
 
 func doWithCancel[T any](ctx context.Context, ch <-chan T, out chan<- T) {
@@ -285,9 +329,9 @@ func doWithCancel[T any](ctx context.Context, ch <-chan T, out chan<- T) {
 
 // OptionMap applies f to every value received from in and sends all non-nil results to its output channel.
 func OptionMap[S, T any](ctx context.Context, in <-chan S, f func(S) *T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doOptionMap(ctx, in, out, f)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doOptionMap(ctx, in, out[0], f)
+	}, configure(opts)))
 }
 
 func doOptionMap[S, T any](ctx context.Context, in <-chan S, out chan<- T, f func(S) *T) {
@@ -315,9 +359,9 @@ func doOptionMap[S, T any](ctx context.Context, in <-chan S, out chan<- T, f fun
 // OptionMapCtx applies f to every value received from in and sends all non-nil results to its output channel.
 // The same context passed to OptionMapCtx is passed as an argument to f.
 func OptionMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S) *T, opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doOptionMapCtx(ctx, in, out, f)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doOptionMapCtx(ctx, in, out[0], f)
+	}, configure(opts)))
 }
 
 func doOptionMapCtx[S, T any](ctx context.Context, in <-chan S, out chan<- T, f func(context.Context, S) *T) {
@@ -355,7 +399,7 @@ func sendAll[T any](ctx context.Context, ts []T, ch chan<- T) {
 }
 
 // ForkMapCtx forks an invocation of f onto a new goroutine for each value received from in.
-// f is passed the output channel directly, and is expected responsible to send its output to this channel.
+// f is passed the output channel directly, and is responsible for sending its output to this channel.
 // To avoid resource leaks, f must respect context cancellation when sending to its output channel.
 // The same context passed to ForkMapCtx is passed to f.
 //
@@ -365,9 +409,9 @@ func sendAll[T any](ctx context.Context, ts []T, ch chan<- T) {
 // ForkMap is omitted because the caller cannot listen for context cancellation in some cases.
 // ForkFlatMap is omitted because it is more efficient for the caller range over the slice and send individual values themselves.
 func ForkMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S, chan<- T), opts ...OptionFunc[T]) <-chan T {
-	return doWithOpts(ctx, opts, func(ctx context.Context, out chan<- T) {
-		doForkMapCtx(ctx, in, f, out)
-	})
+	return return1(doWithConf(ctx, func(ctx context.Context, out ...chan<- T) {
+		doForkMapCtx(ctx, in, f, out[0])
+	}, configure(opts)))
 }
 
 func doForkMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Context, S, chan<- T), out chan<- T) {
@@ -391,35 +435,23 @@ func doForkMapCtx[S, T any](ctx context.Context, in <-chan S, f func(context.Con
 	}
 }
 
-// Drain receives all values from the provided channel and returns them in a slice.
-// Drain blocks the caller until the input channel is closed or the provided context is cancelled.
-// An error is returned if and only if the provided context was cancelled before the input channel was closed.
-func Drain[T any](ctx context.Context, in <-chan T) ([]T, error) {
-	var result []T
-	for {
-		select {
-		case <-ctx.Done():
-			return result, ctx.Err()
-		case repo, ok := <-in:
-			if !ok {
-				return result, nil
-			}
-			result = append(result, repo)
-		}
-	}
-}
-
-// doWithOpts runs the implementation provided via doIt on goroutines according to the provided options.
-func doWithOpts[T any](ctx context.Context, opts []OptionFunc[T], doIt func(context.Context, chan<- T)) <-chan T {
-	conf := configure(opts)
-	out := conf.channer()
+// doWithConf runs the implementation provided via doIt on goroutines according to the provided options.
+func doWithConf[T any](ctx context.Context, doIt func(context.Context, ...chan<- T), conf config[T]) []<-chan T {
+	outs := conf.makeOutputs()
 	if conf.workers == 1 {
-		go func() {
-			defer close(out)
-			doIt(ctx, out)
+		go func() { // avoid any overhead from the WaitGroup.
+			if conf.doneCancel != nil {
+				defer conf.doneCancel()
+			}
+			defer func() {
+				for _, ch := range outs {
+					close(ch)
+				}
+			}()
+			doIt(ctx, sendOnly(outs)...)
 		}()
 	} else {
-		var wg sync.WaitGroup
+		var wg sync.WaitGroup // run on worker pool
 		for i := 0; i < conf.workers; i++ {
 			wg.Add(1)
 			go func(id int) {
@@ -427,16 +459,25 @@ func doWithOpts[T any](ctx context.Context, opts []OptionFunc[T], doIt func(cont
 					wg.Done()
 					if id == 0 { // first thread closes the output channel.
 						wg.Wait()
-						close(out)
+						defer func() {
+							for _, ch := range outs {
+								close(ch)
+							}
+						}()
+						if conf.doneCancel != nil {
+							conf.doneCancel()
+						}
 					}
 				}()
-				doIt(ctx, out)
+				doIt(ctx, sendOnly(outs)...)
 			}(i)
 		}
 	}
-	return out
+	return recvOnly(outs)
 }
 
+// doOnPool performs the function doIt on a pool of size poolSize, closing all channels passed to outs when the
+// invocation of doIt completes.
 func doOnPool[T any](ctx context.Context, poolSize int, doIt func(context.Context, ...chan<- T), outs ...chan<- T) {
 	closeAll := func() {
 		for _, ch := range outs {
@@ -462,6 +503,24 @@ func doOnPool[T any](ctx context.Context, poolSize int, doIt func(context.Contex
 				}()
 				doIt(ctx, outs...)
 			}(i)
+		}
+	}
+}
+
+// Drain receives all values from the provided channel and returns them in a slice.
+// Drain blocks the caller until the input channel is closed or the provided context is cancelled.
+// An error is returned if and only if the provided context was cancelled before the input channel was closed.
+func Drain[T any](ctx context.Context, in <-chan T) ([]T, error) {
+	var result []T
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case repo, ok := <-in:
+			if !ok {
+				return result, nil
+			}
+			result = append(result, repo)
 		}
 	}
 }

--- a/pipelines/pipelines_test.go
+++ b/pipelines/pipelines_test.go
@@ -496,6 +496,7 @@ func testClosesOnContextDone[S, T any](t *testing.T, stage func(context.Context,
 // testClosesAfterDrain blocks and tests whether the provided channel is closed after being drained. Fails after 1
 // second if the channel remains open with no value being received.
 func testClosesAfterDrain[T any](t *testing.T, ch <-chan T) {
+	fmt.Println("testing close!", ch)
 	for {
 		select {
 		case <-time.After(1 * time.Second):

--- a/pipelines/pipelines_test.go
+++ b/pipelines/pipelines_test.go
@@ -13,12 +13,16 @@ import (
 	"time"
 )
 
-// Opts provides a battery of tests configurations in basic combinations.
-func Opts[T any]() optionMap[T] {
+// opts provides a battery of tests configurations in basic combinations.
+func opts[T any]() optionMap[T] {
+	doneOpt, _ := pipelines.WithDone[T](context.Background())
 	return optionMap[T]{
-		"default":     {},
-		"pooled 3":    {pipelines.WithPool[T](3)},
-		"buffered 10": {pipelines.WithBuffer[T](10)},
+		"default":                 {},
+		"pooled 3":                {pipelines.WithPool[T](3)},
+		"buffered 10":             {pipelines.WithBuffer[T](10)},
+		"waitgroup":               {pipelines.WithWaitGroup[T](&sync.WaitGroup{})},
+		"pooled 5+waitgroup":      {pipelines.WithWaitGroup[T](&sync.WaitGroup{}), pipelines.WithPool[T](5)},
+		"pooled 5+waitgroup+done": {pipelines.WithWaitGroup[T](&sync.WaitGroup{}), pipelines.WithPool[T](5), doneOpt},
 	}
 }
 
@@ -30,7 +34,7 @@ func TestFlatMapCtx(t *testing.T) {
 		return []string{fmt.Sprintf("%d", x), fmt.Sprintf("%d!", x)}
 	}
 	t.Run("maps and serializes output", func(t *testing.T) {
-		withOptions[string](t, Opts[string](), func(t *testing.T, opts []pipelines.OptionFunc[string]) {
+		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]int{1, 2, 3})
 			ch := pipelines.FlatMapCtx(ctx, in, double, opts...)
@@ -41,12 +45,17 @@ func TestFlatMapCtx(t *testing.T) {
 		})
 	})
 
-	testClosesOnClose(t, func(ctx context.Context, s <-chan int) <-chan string {
+	optStage := func(ctx context.Context, opt pipelines.Option, s <-chan int) <-chan string {
+		return pipelines.FlatMapCtx(ctx, s, double, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, s <-chan int) <-chan string {
 		return pipelines.FlatMapCtx(ctx, s, double)
-	})
-	testClosesOnContextDone(t, func(ctx context.Context, s <-chan int) <-chan string {
-		return pipelines.FlatMapCtx(ctx, s, double)
-	})
+	}
+	testClosesOnClose(t, stage)
+	testClosesOnContextDone(t, stage)
 }
 
 func TestFlatMap(t *testing.T) {
@@ -57,7 +66,7 @@ func TestFlatMap(t *testing.T) {
 		return []int{x, x * 2}
 	}
 	t.Run("maps and serializes output", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5})
 			ch := pipelines.FlatMap(ctx, in, double, opts...)
@@ -68,12 +77,17 @@ func TestFlatMap(t *testing.T) {
 		})
 	})
 
-	testClosesOnClose(t, func(ctx context.Context, s <-chan int) <-chan int {
+	optStage := func(ctx context.Context, opt pipelines.Option, s <-chan int) <-chan int {
+		return pipelines.FlatMap(ctx, s, double, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, s <-chan int) <-chan int {
 		return pipelines.FlatMap(ctx, s, double)
-	})
-	testClosesOnContextDone(t, func(ctx context.Context, s <-chan int) <-chan int {
-		return pipelines.FlatMap(ctx, s, double)
-	})
+	}
+	testClosesOnClose(t, stage)
+	testClosesOnContextDone(t, stage)
 }
 
 func TestCombine(t *testing.T) {
@@ -83,7 +97,7 @@ func TestCombine(t *testing.T) {
 	t.Parallel()
 
 	t.Run("combines values", func(t *testing.T) {
-		withOptions[string](t, Opts[string](), func(t *testing.T, opts []pipelines.OptionFunc[string]) {
+		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			ch1 := pipelines.Chan([]string{"1", "2", "3"})
 			ch2 := pipelines.Chan([]string{"4", "5", "6"})
@@ -97,19 +111,29 @@ func TestCombine(t *testing.T) {
 
 	closed := make(chan int)
 	close(closed)
+
 	// each argument channel must be tested separately
-	testClosesOnClose(t, func(ctx context.Context, in1 <-chan int) <-chan int {
+	optStage1 := func(ctx context.Context, opt pipelines.Option, in1 <-chan int) <-chan int {
+		return pipelines.Combine(ctx, in1, closed, opt)
+	}
+	optStage2 := func(ctx context.Context, opt pipelines.Option, in2 <-chan int) <-chan int {
+		return pipelines.Combine(ctx, closed, in2, opt)
+	}
+	testWithDone(t, optStage1)
+	testWithDone(t, optStage2)
+	testWithWaitGroup(t, optStage1)
+	testWithWaitGroup(t, optStage2)
+
+	stage1 := func(ctx context.Context, in1 <-chan int) <-chan int {
 		return pipelines.Combine(ctx, in1, closed)
-	})
-	testClosesOnClose(t, func(ctx context.Context, in2 <-chan int) <-chan int {
+	}
+	stage2 := func(ctx context.Context, in2 <-chan int) <-chan int {
 		return pipelines.Combine(ctx, closed, in2)
-	})
-	testClosesOnContextDone(t, func(ctx context.Context, in1 <-chan int) <-chan int {
-		return pipelines.Combine(ctx, in1, closed)
-	})
-	testClosesOnContextDone(t, func(ctx context.Context, in2 <-chan int) <-chan int {
-		return pipelines.Combine(ctx, closed, in2)
-	})
+	}
+	testClosesOnClose(t, stage1)
+	testClosesOnClose(t, stage2)
+	testClosesOnContextDone(t, stage1)
+	testClosesOnContextDone(t, stage2)
 }
 
 func TestTee(t *testing.T) {
@@ -118,7 +142,7 @@ func TestTee(t *testing.T) {
 	t.Parallel()
 
 	t.Run("forks values", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{0, 1, 2, 3})
@@ -168,7 +192,7 @@ func TestForkMapCtx(t *testing.T) {
 	}
 
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{0, 1, 2})
@@ -178,12 +202,17 @@ func TestForkMapCtx(t *testing.T) {
 			is.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8}, out)
 		})
 	})
-	testClosesOnClose(t, func(ctx context.Context, in <-chan int) <-chan int {
+	optStage := func(ctx context.Context, opt pipelines.Option, in <-chan int) <-chan int {
+		return pipelines.ForkMapCtx(ctx, in, triplify, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, in <-chan int) <-chan int {
 		return pipelines.ForkMapCtx(ctx, in, triplify)
-	})
-	testClosesOnContextDone(t, func(ctx context.Context, in <-chan int) <-chan int {
-		return pipelines.ForkMapCtx(ctx, in, triplify)
-	})
+	}
+	testClosesOnClose(t, stage)
+	testClosesOnContextDone(t, stage)
 }
 
 func TestMapCtx(t *testing.T) {
@@ -195,7 +224,7 @@ func TestMapCtx(t *testing.T) {
 		return len(s)
 	}
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]string{"ab", "abcd", "abcdef", ""})
 			ch := pipelines.MapCtx(ctx, in, lenCtx, opts...)
@@ -206,12 +235,17 @@ func TestMapCtx(t *testing.T) {
 		})
 	})
 
-	testClosesOnContextDone(t, func(ctx context.Context, in <-chan string) <-chan int {
+	optStage := func(ctx context.Context, opt pipelines.Option, in <-chan string) <-chan int {
+		return pipelines.MapCtx(ctx, in, lenCtx, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, in <-chan string) <-chan int {
 		return pipelines.MapCtx(ctx, in, lenCtx)
-	})
-	testClosesOnClose(t, func(ctx context.Context, in <-chan string) <-chan int {
-		return pipelines.MapCtx(ctx, in, lenCtx)
-	})
+	}
+	testClosesOnContextDone(t, stage)
+	testClosesOnClose(t, stage)
 }
 
 func TestMap(t *testing.T) {
@@ -220,7 +254,7 @@ func TestMap(t *testing.T) {
 	t.Parallel()
 
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[string](t, Opts[string](), func(t *testing.T, opts []pipelines.OptionFunc[string]) {
+		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5})
@@ -231,13 +265,16 @@ func TestMap(t *testing.T) {
 			is.Equal([]string{"1", "2", "3", "4", "5"}, out)
 		})
 	})
-
-	testClosesOnContextDone(t, func(ctx context.Context, in <-chan int) <-chan string {
+	optStage := func(ctx context.Context, opt pipelines.Option, in <-chan int) <-chan string {
+		return pipelines.Map(ctx, in, strconv.Itoa, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+	stage := func(ctx context.Context, in <-chan int) <-chan string {
 		return pipelines.Map(ctx, in, strconv.Itoa)
-	})
-	testClosesOnClose(t, func(ctx context.Context, in <-chan int) <-chan string {
-		return pipelines.Map(ctx, in, strconv.Itoa)
-	})
+	}
+	testClosesOnContextDone(t, stage)
+	testClosesOnClose(t, stage)
 }
 
 func TestOptionMap(t *testing.T) {
@@ -254,7 +291,7 @@ func TestOptionMap(t *testing.T) {
 	}
 
 	t.Run("maps and filters all values", func(t *testing.T) {
-		withOptions[string](t, Opts[string](), func(t *testing.T, opts []pipelines.OptionFunc[string]) {
+		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5, 6})
@@ -265,13 +302,17 @@ func TestOptionMap(t *testing.T) {
 			is.Equal([]string{"2", "4", "6"}, out)
 		})
 	})
+	optStage := func(ctx context.Context, opt pipelines.Option, in <-chan int) <-chan string {
+		return pipelines.OptionMap(ctx, in, evenStrConv, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
 
-	testClosesOnContextDone(t, func(ctx context.Context, in <-chan int) <-chan string {
+	stage := func(ctx context.Context, in <-chan int) <-chan string {
 		return pipelines.OptionMap(ctx, in, evenStrConv)
-	})
-	testClosesOnClose(t, func(ctx context.Context, in <-chan int) <-chan string {
-		return pipelines.OptionMap(ctx, in, evenStrConv)
-	})
+	}
+	testClosesOnContextDone(t, stage)
+	testClosesOnClose(t, stage)
 }
 
 func TestOptionMapCtx(t *testing.T) {
@@ -287,7 +328,7 @@ func TestOptionMapCtx(t *testing.T) {
 		return nil
 	}
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]string{"ab", "a", "abcd", "abcdef", "abc", ""})
 			ch := pipelines.OptionMapCtx(ctx, in, lenCtx, opts...)
@@ -298,12 +339,17 @@ func TestOptionMapCtx(t *testing.T) {
 		})
 	})
 
-	testClosesOnContextDone(t, func(ctx context.Context, in <-chan string) <-chan int {
+	optStage := func(ctx context.Context, opt pipelines.Option, in <-chan string) <-chan int {
+		return pipelines.OptionMapCtx(ctx, in, lenCtx, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, in <-chan string) <-chan int {
 		return pipelines.OptionMapCtx(ctx, in, lenCtx)
-	})
-	testClosesOnClose(t, func(ctx context.Context, in <-chan string) <-chan int {
-		return pipelines.OptionMapCtx(ctx, in, lenCtx)
-	})
+	}
+	testClosesOnContextDone(t, stage)
+	testClosesOnClose(t, stage)
 }
 
 func TestFlatten(t *testing.T) {
@@ -312,7 +358,7 @@ func TestFlatten(t *testing.T) {
 	t.Parallel()
 
 	t.Run("flattens all values", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([][]int{{1, 2, 3}, {4, 5, 6}, {}, {7}})
@@ -324,12 +370,17 @@ func TestFlatten(t *testing.T) {
 		})
 	})
 
-	testClosesOnContextDone(t, func(ctx context.Context, s <-chan []int) <-chan int {
+	optStage := func(ctx context.Context, opt pipelines.Option, s <-chan []int) <-chan int {
+		return pipelines.Flatten[int](ctx, s, opt)
+	}
+	testWithDone(t, optStage)
+	testWithWaitGroup(t, optStage)
+
+	stage := func(ctx context.Context, s <-chan []int) <-chan int {
 		return pipelines.Flatten[int](ctx, s)
-	})
-	testClosesOnClose(t, func(ctx context.Context, s <-chan []int) <-chan int {
-		return pipelines.Flatten[int](ctx, s)
-	})
+	}
+	testClosesOnContextDone(t, stage)
+	testClosesOnClose(t, stage)
 }
 
 func TestChan(t *testing.T) {
@@ -363,7 +414,7 @@ func TestWithCancel(t *testing.T) {
 
 	t.Parallel()
 	t.Run("result channel closes on context done", func(t *testing.T) {
-		withOptions[int](t, Opts[int](), func(t *testing.T, opts []pipelines.OptionFunc[int]) {
+		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
 			in := make(chan int)
 			ctx, cancel := context.WithCancel(ctx)
 			cancel()
@@ -473,7 +524,53 @@ func TestReduce(t *testing.T) {
 	})
 }
 
+func testWithWaitGroup[S, T any](t *testing.T, stage func(context.Context, pipelines.Option, <-chan S) <-chan T) {
+	t.Helper()
+	t.Run("WithWaitGroup", func(t *testing.T) {
+		ctx := context.Background()
+		var wg sync.WaitGroup
+
+		in := make(chan S)
+		out := stage(ctx, pipelines.WithWaitGroup[T](&wg), in)
+		close(in)
+		testClosesAfterDrain(t, out)
+
+		// validate WaitGroup has hit zero
+		complete := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(complete)
+		}()
+
+		select {
+		case <-time.After(1 * time.Second):
+			t.Errorf("done not cancelled: timed out")
+		case <-complete:
+			return
+		}
+	})
+}
+
+func testWithDone[S, T any](t *testing.T, stage func(context.Context, pipelines.Option, <-chan S) <-chan T) {
+	t.Helper()
+	t.Run("WithDone", func(t *testing.T) {
+		in := make(chan S)
+		opt, ctx := pipelines.WithDone[T](context.Background())
+		out := stage(ctx, opt, in)
+		close(in)
+		testClosesAfterDrain(t, out)
+		select {
+		case <-time.After(1 * time.Second):
+			t.Errorf("done not cancelled: timed out")
+			return
+		case <-ctx.Done():
+			return
+		}
+	})
+}
+
 func testClosesOnClose[S, T any](t *testing.T, stage func(context.Context, <-chan S) <-chan T) {
+	t.Helper()
 	t.Run("closes on closed input channel", func(t *testing.T) {
 		in := make(chan S)
 		close(in)
@@ -484,6 +581,7 @@ func testClosesOnClose[S, T any](t *testing.T, stage func(context.Context, <-cha
 
 // testClosesOnContextDone tests that a pipeline stage closes its output channel when the context is closed.
 func testClosesOnContextDone[S, T any](t *testing.T, stage func(context.Context, <-chan S) <-chan T) {
+	t.Helper()
 	t.Run("result channel closes on context done", func(t *testing.T) {
 		in := make(chan S)
 		ctx, cancel := context.WithCancel(context.Background())
@@ -496,7 +594,7 @@ func testClosesOnContextDone[S, T any](t *testing.T, stage func(context.Context,
 // testClosesAfterDrain blocks and tests whether the provided channel is closed after being drained. Fails after 1
 // second if the channel remains open with no value being received.
 func testClosesAfterDrain[T any](t *testing.T, ch <-chan T) {
-	fmt.Println("testing close!", ch)
+	t.Helper()
 	for {
 		select {
 		case <-time.After(1 * time.Second):
@@ -513,6 +611,7 @@ func testClosesAfterDrain[T any](t *testing.T, ch <-chan T) {
 // drain blocks and drains the provided channel, returning the sequence of values received as a slice. Returns once the
 // channel has been closed.
 func drain[T any](t *testing.T, ch <-chan T) []T {
+	t.Helper()
 	var result []T
 	for {
 		select {
@@ -528,9 +627,10 @@ func drain[T any](t *testing.T, ch <-chan T) []T {
 	}
 }
 
-type optionMap[T any] map[string][]pipelines.OptionFunc[T]
+type optionMap[T any] map[string][]pipelines.Option
 
-func withOptions[T any](t *testing.T, opts optionMap[T], f func(*testing.T, []pipelines.OptionFunc[T])) {
+func withOptions[T any](t *testing.T, opts optionMap[T], f func(*testing.T, []pipelines.Option)) {
+	t.Helper()
 	for name, options := range opts {
 		t.Run(name, func(t *testing.T) {
 			f(t, options)

--- a/pipelines/pipelines_test.go
+++ b/pipelines/pipelines_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 // opts provides a battery of tests configurations in basic combinations.
-func opts[T any]() optionMap[T] {
-	doneOpt, _ := pipelines.WithDone[T](context.Background())
-	return optionMap[T]{
+func opts() optionMap {
+	doneOpt, _ := pipelines.WithDone(context.Background())
+	return optionMap{
 		"default":                 {},
-		"pooled 3":                {pipelines.WithPool[T](3)},
-		"buffered 10":             {pipelines.WithBuffer[T](10)},
-		"waitgroup":               {pipelines.WithWaitGroup[T](&sync.WaitGroup{})},
-		"pooled 5+waitgroup":      {pipelines.WithWaitGroup[T](&sync.WaitGroup{}), pipelines.WithPool[T](5)},
-		"pooled 5+waitgroup+done": {pipelines.WithWaitGroup[T](&sync.WaitGroup{}), pipelines.WithPool[T](5), doneOpt},
+		"pooled 3":                {pipelines.WithPool(3)},
+		"buffered 10":             {pipelines.WithBuffer(10)},
+		"waitgroup":               {pipelines.WithWaitGroup(&sync.WaitGroup{})},
+		"pooled 5+waitgroup":      {pipelines.WithWaitGroup(&sync.WaitGroup{}), pipelines.WithPool(5)},
+		"pooled 5+waitgroup+done": {pipelines.WithWaitGroup(&sync.WaitGroup{}), pipelines.WithPool(5), doneOpt},
 	}
 }
 
@@ -34,7 +34,7 @@ func TestFlatMapCtx(t *testing.T) {
 		return []string{fmt.Sprintf("%d", x), fmt.Sprintf("%d!", x)}
 	}
 	t.Run("maps and serializes output", func(t *testing.T) {
-		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]int{1, 2, 3})
 			ch := pipelines.FlatMapCtx(ctx, in, double, opts...)
@@ -66,7 +66,7 @@ func TestFlatMap(t *testing.T) {
 		return []int{x, x * 2}
 	}
 	t.Run("maps and serializes output", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5})
 			ch := pipelines.FlatMap(ctx, in, double, opts...)
@@ -97,7 +97,7 @@ func TestCombine(t *testing.T) {
 	t.Parallel()
 
 	t.Run("combines values", func(t *testing.T) {
-		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			ch1 := pipelines.Chan([]string{"1", "2", "3"})
 			ch2 := pipelines.Chan([]string{"4", "5", "6"})
@@ -142,7 +142,7 @@ func TestTee(t *testing.T) {
 	t.Parallel()
 
 	t.Run("forks values", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{0, 1, 2, 3})
@@ -192,7 +192,7 @@ func TestForkMapCtx(t *testing.T) {
 	}
 
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{0, 1, 2})
@@ -224,7 +224,7 @@ func TestMapCtx(t *testing.T) {
 		return len(s)
 	}
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]string{"ab", "abcd", "abcdef", ""})
 			ch := pipelines.MapCtx(ctx, in, lenCtx, opts...)
@@ -254,7 +254,7 @@ func TestMap(t *testing.T) {
 	t.Parallel()
 
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5})
@@ -291,7 +291,7 @@ func TestOptionMap(t *testing.T) {
 	}
 
 	t.Run("maps and filters all values", func(t *testing.T) {
-		withOptions[string](t, opts[string](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([]int{1, 2, 3, 4, 5, 6})
@@ -328,7 +328,7 @@ func TestOptionMapCtx(t *testing.T) {
 		return nil
 	}
 	t.Run("maps all values", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 			in := pipelines.Chan([]string{"ab", "a", "abcd", "abcdef", "abc", ""})
 			ch := pipelines.OptionMapCtx(ctx, in, lenCtx, opts...)
@@ -358,7 +358,7 @@ func TestFlatten(t *testing.T) {
 	t.Parallel()
 
 	t.Run("flattens all values", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			is := is.New(t)
 
 			in := pipelines.Chan([][]int{{1, 2, 3}, {4, 5, 6}, {}, {7}})
@@ -371,13 +371,13 @@ func TestFlatten(t *testing.T) {
 	})
 
 	optStage := func(ctx context.Context, opt pipelines.Option, s <-chan []int) <-chan int {
-		return pipelines.Flatten[int](ctx, s, opt)
+		return pipelines.Flatten(ctx, s, opt)
 	}
 	testWithDone(t, optStage)
 	testWithWaitGroup(t, optStage)
 
 	stage := func(ctx context.Context, s <-chan []int) <-chan int {
-		return pipelines.Flatten[int](ctx, s)
+		return pipelines.Flatten(ctx, s)
 	}
 	testClosesOnContextDone(t, stage)
 	testClosesOnClose(t, stage)
@@ -414,7 +414,7 @@ func TestWithCancel(t *testing.T) {
 
 	t.Parallel()
 	t.Run("result channel closes on context done", func(t *testing.T) {
-		withOptions[int](t, opts[int](), func(t *testing.T, opts []pipelines.Option) {
+		withOptions(t, opts(), func(t *testing.T, opts []pipelines.Option) {
 			in := make(chan int)
 			ctx, cancel := context.WithCancel(ctx)
 			cancel()
@@ -531,7 +531,7 @@ func testWithWaitGroup[S, T any](t *testing.T, stage func(context.Context, pipel
 		var wg sync.WaitGroup
 
 		in := make(chan S)
-		out := stage(ctx, pipelines.WithWaitGroup[T](&wg), in)
+		out := stage(ctx, pipelines.WithWaitGroup(&wg), in)
 		close(in)
 		testClosesAfterDrain(t, out)
 
@@ -555,7 +555,7 @@ func testWithDone[S, T any](t *testing.T, stage func(context.Context, pipelines.
 	t.Helper()
 	t.Run("WithDone", func(t *testing.T) {
 		in := make(chan S)
-		opt, ctx := pipelines.WithDone[T](context.Background())
+		opt, ctx := pipelines.WithDone(context.Background())
 		out := stage(ctx, opt, in)
 		close(in)
 		testClosesAfterDrain(t, out)
@@ -627,9 +627,9 @@ func drain[T any](t *testing.T, ch <-chan T) []T {
 	}
 }
 
-type optionMap[T any] map[string][]pipelines.Option
+type optionMap map[string][]pipelines.Option
 
-func withOptions[T any](t *testing.T, opts optionMap[T], f func(*testing.T, []pipelines.Option)) {
+func withOptions(t *testing.T, opts optionMap, f func(*testing.T, []pipelines.Option)) {
 	t.Helper()
 	for name, options := range opts {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
- Cleans up some overcomplicated code; simplifies the functional options API.
- Adds `pipelines.WithDone()` and `pipelines.WithWaitGroup()` options for detecting the termination of all goroutines associated with one or more pipeline stages.